### PR TITLE
fix: omit peer dependencies warning when using angular 9 or ionic 5

### DIFF
--- a/projects/ngx-ionic-image-viewer/package.json
+++ b/projects/ngx-ionic-image-viewer/package.json
@@ -39,8 +39,8 @@
     "url": "https://github.com/simongolms/ngx-ionic-image-viewer/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^8.2.13",
-    "@angular/core": "^8.2.13",
-    "@ionic/angular": "4.0.0"
+    "@angular/common": ">=8.2.13",
+    "@angular/core": ">=8.2.13",
+    "@ionic/angular": ">=4.0.0"
   }
 }


### PR DESCRIPTION
In `angular@^9` or `@ionic/angular@^5` project, npm will show up peer dependencies warning when installing/upgrading this package:

```
npm WARN ngx-ionic-image-viewer@0.7.0 requires a peer of @angular/common@^8.2.13 but none is installed. You must install peer dependencies yourself.
npm WARN ngx-ionic-image-viewer@0.7.0 requires a peer of @angular/core@^8.2.13 but none is installed. You must install peer dependencies yourself.
npm WARN ngx-ionic-image-viewer@0.7.0 requires a peer of @ionic/angular@4.0.0 but none is installed. You must install peer dependencies yourself.
```

This PR will omit the peer dependencies warning 👍

Reference: https://github.com/ionic-team/ionic/blob/master/angular/package.json#L49