### PR TITLE
Add missing comma in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ export class HomePage {
       componentProps: {
         src: "./assets/img/demo.jpg"
       },
-      cssClass: 'ion-img-viewer'
+      cssClass: 'ion-img-viewer',
       keyboardClose: true,
       showBackdrop: true
     });


### PR DESCRIPTION
The example in the controller section is missing a comma. This pull requests fixes the typo. 